### PR TITLE
feat(cli): flag to preserve output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ OPTIONS
   -e, --environment=environment  environment
   -h, --help                     show CLI help
   -o, --out=out                  output directory
+  -p, --preserve                 preserve output folder
   -s, --spaceId=spaceId          space id
   -t, --token=token              management token
   -v, --version                  show CLI version

--- a/src/cf-definitions-builder.ts
+++ b/src/cf-definitions-builder.ts
@@ -1,7 +1,6 @@
-import {renderProp} from './renderer/cf-render-prop';
+import {Field} from 'contentful';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import {Field} from 'contentful';
 import {
     forEachStructureChild,
     ImportDeclarationStructure,
@@ -12,9 +11,10 @@ import {
     SourceFile,
     StructureKind,
 } from 'ts-morph';
-import {moduleFieldsName, moduleName} from './utils';
 import {propertyImports} from './cf-property-imports';
+import {renderProp} from './renderer/cf-render-prop';
 import {renderGenericType} from './renderer/render-generic-type';
+import {moduleFieldsName, moduleName} from './utils';
 
 export type CFContentType = {
     name: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-import * as fs from 'fs-extra';
 import {Command, flags} from '@oclif/command';
+import * as fs from 'fs-extra';
+import * as path from 'path';
 import CFDefinitionsBuilder from './cf-definitions-builder';
 
 const contentfulExport = require('contentful-export');
@@ -10,7 +11,11 @@ class ContentfulMdg extends Command {
     static flags = {
         version: flags.version({char: 'v'}),
         help: flags.help({char: 'h'}),
+
         out: flags.string({char: 'o', description: 'output directory'}),
+        preserve: flags.boolean({char: 'p', description: 'preserve output folder'}),
+
+        // remote access
         spaceId: flags.string({char: 's', description: 'space id'}),
         token: flags.string({char: 't', description: 'management token'}),
         environment: flags.string({char: 'e', description: 'environment'}),
@@ -50,6 +55,11 @@ class ContentfulMdg extends Command {
         content.contentTypes.forEach(builder.appendType);
 
         if (flags.out) {
+            const outDir = path.resolve(flags.out);
+            if (!flags.preserve && fs.existsSync(outDir)) {
+                await fs.remove(outDir);
+            }
+            await fs.ensureDir(outDir);
             await builder.write(flags.out);
         } else {
             this.log(builder.toString());


### PR DESCRIPTION
By default we remove or/and ensure the output folder.
If this behaviour is not wanted, we can preserve an existing output folder and override existing files.