### PR TITLE
Add guards for potentially undefined field

### DIFF
--- a/src/cf-property-types.ts
+++ b/src/cf-property-types.ts
@@ -3,7 +3,7 @@ import {renderUnionType} from './renderer/render-union-type';
 import {Field} from 'contentful';
 
 export const anyType = (field: Field): string => {
-    if (field.validations.length > 0) {
+    if (field.validations?.length > 0) {
         const includesValidation = field.validations.find(validation => validation.in);
         if (includesValidation && includesValidation.in) {
             const mapper = (): (value: string) => string => {

--- a/src/renderer/cf-render-prop-array.ts
+++ b/src/renderer/cf-render-prop-array.ts
@@ -16,7 +16,7 @@ export const renderPropArray = (field: Field): string => {
     if (field.items.type === 'Symbol') {
         const validation = inValidations(field.items);
 
-        if (validation.length > 0) {
+        if (validation?.length > 0) {
             return `(${renderUnionType(validation.map(renderLiteralType))})[]`;
         }
         return 'Contentful.EntryFields.Symbol[]';

--- a/src/renderer/cf-render-prop-link.ts
+++ b/src/renderer/cf-render-prop-link.ts
@@ -5,11 +5,11 @@ import {renderUnionType} from './render-union-type';
 
 const linkContentType = (field: Pick<Field, 'id' | 'validations'>): string => {
     const validations = linkContentTypeValidations(field);
-    return renderUnionType(validations.length > 0 ? validations.map(moduleFieldsName) : ['any']);
+    return renderUnionType(validations?.length > 0 ? validations.map(moduleFieldsName) : ['any']);
 };
 
 export const renderPropLink = (field: Pick<Field, 'id' | 'validations' | 'linkType'>) => {
-    const value = field.validations.length === 0 ? 'any' : linkContentType(field);
+    const value = field.validations && field.validations.length === 0 ? 'any' : linkContentType(field);
     return field.linkType === 'Entry'
         ? renderGenericType('Contentful.' + field.linkType, value)
         : 'Contentful.' + field.linkType!;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ export const moduleFieldsName = (name: string): string => moduleName(name) + 'Fi
 type WithValidations = Pick<FieldItem, 'validations'>;
 
 const validation = (node: WithValidations, field: keyof FieldValidation): any => {
-    if (node.validations.length !== 0) {
+    if (node.validations && node.validations.length !== 0) {
         const linkContentValidation = node.validations.find(value => value[field]);
         if (linkContentValidation) {
             return linkContentValidation[field] || [];

--- a/test/cf-render-prop.test.ts
+++ b/test/cf-render-prop.test.ts
@@ -2,7 +2,7 @@ import { renderProp } from '../src/renderer/cf-render-prop';
 import {expect} from '@oclif/test';
 
 describe('A renderProp function', () => {
-    it('can evaluate an "Symbol" type', () => {
+    it('can evaluate a "Symbol" type', () => {
         const field = JSON.parse(`
         {
           "id": "internalName",
@@ -20,7 +20,7 @@ describe('A renderProp function', () => {
         expect(renderProp(field)).to.equal('Contentful.EntryFields.Symbol');
     });
 
-    it('can evaluate an "Symbol" type with "in" validation', () => {
+    it('can evaluate a "Symbol" type with "in" validation', () => {
         const field = JSON.parse(`
         {
           "id": "headerAlignment",
@@ -42,6 +42,22 @@ describe('A renderProp function', () => {
         `);
 
         expect(renderProp(field)).to.equal('"Left-aligned" | "Center-aligned"');
+    });
+
+    it('can evaluate a "Symbol" type with missing validations', () => {
+      const field = JSON.parse(`
+      {
+        "id": "internalName",
+        "name": "Internal name",
+        "type": "Symbol",
+        "localized": false,
+        "required": false,
+        "disabled": false,
+        "omitted": false
+      }
+      `);
+
+      expect(renderProp(field)).to.equal('Contentful.EntryFields.Symbol');
     });
 
     it('can evaluate a "Link" type', () => {


### PR DESCRIPTION
It is possible that the `validations` on an entity field can be undefined, leading to type errors. This change adds guards to avoid this situation.

Resolves #18 

