### PR TITLE
fix(imports): self references

### DIFF
--- a/src/cf-definitions-builder.ts
+++ b/src/cf-definitions-builder.ts
@@ -140,7 +140,8 @@ export default class CFDefinitionsBuilder {
             moduleSpecifier: '@contentful/rich-text-types',
             namespaceImport: 'CFRichTextTypes',
         });
-        file.addImportDeclarations(propertyImports(field));
+
+        file.addImportDeclarations(propertyImports(field, file.getBaseNameWithoutExtension()));
     };
 
     private mergeFile = (mergeFileName = 'ContentTypes'): SourceFile => {

--- a/src/cf-property-imports.ts
+++ b/src/cf-property-imports.ts
@@ -9,12 +9,18 @@ const moduleImport = (module: string) => ({
     ],
 });
 
-export const propertyImports = (field: Field): OptionalKind<ImportDeclarationStructure>[] => {
+export const propertyImports = (field: Field, ignoreModule?: string): OptionalKind<ImportDeclarationStructure>[] => {
+    const filterIgnoredModule = (name: string) => ignoreModule !== moduleName(name);
+
     if (field.type === 'Link' && field.linkType === 'Entry') {
-        return linkContentTypeValidations(field).map(moduleImport);
+        return linkContentTypeValidations(field)
+            .filter(filterIgnoredModule)
+            .map(moduleImport);
     }
     if (field.type === 'Array' && field.items) {
-        return linkContentTypeValidations(field.items).map(moduleImport);
+        return linkContentTypeValidations(field.items)
+            .filter(filterIgnoredModule)
+            .map(moduleImport);
     }
     return [];
 };


### PR DESCRIPTION
When a type references itself in one of the fields, no self referencing imports should be added.

Fixes #19