### PR TITLE
fix(export): types only export for index file

### DIFF
--- a/src/cf-definitions-builder.ts
+++ b/src/cf-definitions-builder.ts
@@ -102,6 +102,7 @@ export default class CFDefinitionsBuilder {
 
         files.forEach(fileName => {
             indexFile.addExportDeclaration({
+                isTypeOnly: true,
                 namedExports: [moduleName(fileName), moduleFieldsName(fileName)],
                 moduleSpecifier: `./${fileName}`,
             });

--- a/test/cf-definitions-builder.test.ts
+++ b/test/cf-definitions-builder.test.ts
@@ -399,7 +399,7 @@ describe('A Contentful definitions builder', () => {
 
         const result1 = await fs.readFile(path.resolve(fixturesPath, 'index.ts'));
         expect('\n' + result1.toString()).to.equal(stripIndent(`
-            export { TypeSysId, TypeSysIdFields } from "./TypeSysId";
+            export type { TypeSysId, TypeSysIdFields } from "./TypeSysId";
             `));
     });
 


### PR DESCRIPTION
export index (barrel) file with `isTypeOnly` flag.

**Before:**
```typescript
export { TypeSysId, TypeSysIdFields } from "./TypeSysId";
```

**After:**
```typescript
export type { TypeSysId, TypeSysIdFields } from "./TypeSysId";
```