### PR TITLE
feat: use Contentful.EntryFields.RichText

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,13 +210,12 @@ As input a [json file](https://github.com/contentful/contentful-cli/tree/master/
 
 ### Output 
 ```typescript
-import * as CFRichTextTypes from "@contentful/rich-text-types";
 import * as Contentful from "contentful";
 
 export interface TypeArtistFields {
     name: Contentful.EntryFields.Symbol;
     profilePicture?: Contentful.Asset;
-    bio?: CFRichTextTypes.Block | CFRichTextTypes.Inline;
+    bio?: Contentful.EntryFields.RichText;
 }
 
 export type TypeArtist = Contentful.Entry<TypeArtistFields>;

--- a/src/cf-definitions-builder.ts
+++ b/src/cf-definitions-builder.ts
@@ -125,23 +125,19 @@ export default class CFDefinitionsBuilder {
         declaration: InterfaceDeclaration,
         field: Field,
     ): void => {
+        const renderedProp = renderProp(field);
         declaration.addProperty({
             name: field.id,
             hasQuestionToken: field.omitted || (!field.required),
-            type: renderProp(field),
+            type: renderedProp,
         });
 
-        // eslint-disable-next-line no-warning-comments
-        // TODO: dynamically define imports based on usage
-        file.addImportDeclaration({
-            moduleSpecifier: 'contentful',
-            namespaceImport: 'Contentful',
-        });
-
-        file.addImportDeclaration({
-            moduleSpecifier: '@contentful/rich-text-types',
-            namespaceImport: 'CFRichTextTypes',
-        });
+        if (renderedProp.includes('Contentful.')) {
+            file.addImportDeclaration({
+                moduleSpecifier: 'contentful',
+                namespaceImport: 'Contentful',
+            });
+        }
 
         file.addImportDeclarations(propertyImports(field, file.getBaseNameWithoutExtension()));
     };

--- a/src/renderer/cf-render-prop.ts
+++ b/src/renderer/cf-render-prop.ts
@@ -1,5 +1,4 @@
 import {Field} from 'contentful';
-import {renderUnionType} from './render-union-type';
 import {renderPropLink} from './cf-render-prop-link';
 import {renderPropArray} from './cf-render-prop-array';
 import {anyType} from '../cf-property-types';
@@ -7,7 +6,7 @@ import {anyType} from '../cf-property-types';
 export const renderProp = (field: Field): string => {
     switch (field.type) {
     case 'RichText':
-        return renderUnionType(['CFRichTextTypes.Block', 'CFRichTextTypes.Inline']);
+        return 'Contentful.EntryFields.RichText';
     case 'Link':
         return renderPropLink(field);
     case 'Array':

--- a/test/cf-render-prop.test.ts
+++ b/test/cf-render-prop.test.ts
@@ -209,4 +209,22 @@ describe('A renderProp function', () => {
 
         expect(renderProp(field)).to.equal('Contentful.Entry<TypeComponentCtaFields | TypeComponentFaqFields | TypeWrapperImageFields | TypeWrapperVideoFields>[]');
     });
+
+    it('can evaluate a "RichText" type', () => {
+      const field = JSON.parse(`
+      {
+        "id": "text",
+        "name": "Text",
+        "type": "RichText",
+        "localized": false,
+        "required": false,
+        "validations": [
+        ],
+        "disabled": false,
+        "omitted": false
+      }
+      `);
+
+      expect(renderProp(field)).to.equal('Contentful.EntryFields.RichText');
+  });
 });


### PR DESCRIPTION
fixes: #10

Replaces `CFRichTextTypes.Block | CFRichTextTypes.Inline` with `Contentful.EntryFields.RichText`. I also took a stab at resolving this TODO: https://github.com/contentful-labs/cf-content-types-generator/blob/master/src/cf-definitions-builder.ts#L135, it is a fairly naive approach but it works for all the current cases.