### PR TITLE
chore: normalize package bin path for npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ import type { TypeAnimal } from './@types/generated';
 npm install cf-content-types-generator contentful
 ```
 
-Repo dev uses `pnpm@9.15.9` via Corepack:
-
-```bash
-corepack enable
-pnpm install
-```
-
 ## Quickstart In 60 Seconds
 
 You can generate types in two ways:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Marco Link<marco.link@contentful.com>",
   "license": "MIT",
   "bin": {
-    "cf-content-types-generator": "./bin/run"
+    "cf-content-types-generator": "bin/run"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary
- normalize the package `bin` path from `./bin/run` to `bin/run`
- avoid npm publish auto-correction warnings on future releases

## Why
The `v3.0.0` release succeeded, but npm warned that it auto-corrected the `bin` entry during publish. This change makes the package metadata match npm's preferred form.

## Validation
- `npm pack --dry-run --cache /tmp/cfctg-npm-cache`
