### PR TITLE
docs: fix README install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import type { TypeAnimal } from './@types/generated';
 ## Install
 
 ```bash
-npm install cf-content-types-generator contentful
+npm install cf-content-types-generator
 ```
 
 ## Quickstart In 60 Seconds

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import type { TypeAnimal } from './@types/generated';
 ## Install
 
 ```bash
-npm install cf-content-types-generator
+npm install --save-dev cf-content-types-generator
 ```
 
 ## Quickstart In 60 Seconds


### PR DESCRIPTION
## Summary
- fix the README install snippet to only install `cf-content-types-generator`

## Why
The previous command incorrectly included `contentful`.
