### PR TITLE
fix: correct oclif single-command config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,5 +78,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build
+        run: pnpm build
+
       - name: Run Tests
         run: pnpm test:coverage

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   },
   "packageManager": "pnpm@9.15.9",
   "oclif": {
-    "default": ".",
-    "commands": "./lib/commands"
+    "commands": {
+      "strategy": "single",
+      "target": "./lib/commands/index"
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- switch oclif config from pattern command discovery to single-command discovery
- point oclif at the existing root command implementation in `lib/commands/index`
- restore expected `bin/dev` behavior for flags and positional file args

## Proof
- before: `./bin/dev -s foo -t bar -e baz` failed with `command -s not found`
- before: `./bin/dev test/cases/fixtures/01-input.json -o /tmp/cfctg-proof` failed with `command test/cases/fixtures/01-input.json not found`
- after: same fake-credential command reaches Contentful API and fails with a real 404 instead of arg parsing failure
- after: `./bin/dev test/cases/fixtures/01-input.json -o /tmp/cfctg-proof` succeeds and writes generated files

Fixes #457