### PR TITLE
ci: gate release on CI workflow

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,7 +1,11 @@
 name: Semantic Release
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
     branches:
       - master
       - v3
@@ -10,8 +14,9 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build & Release
+  release:
+    name: Release
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -23,6 +28,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Restore triggering branch
+        run: git checkout -B "${{ github.event.workflow_run.head_branch }}" "${{ github.event.workflow_run.head_sha }}"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -39,18 +48,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run Lint
-        run: pnpm lint
-
-      - name: Run Tests
-        run: pnpm test:coverage
-
       - name: Release
         run: pnpm semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Coveralls
-        uses: coverallsapp/github-action@v2.3.6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,5 +78,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build
+        run: pnpm build
+
       - name: Run Tests
         run: pnpm test:coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,3 +83,8 @@ jobs:
 
       - name: Run Tests
         run: pnpm test:coverage
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   },
   "packageManager": "pnpm@9.15.9",
   "oclif": {
-    "default": ".",
-    "commands": "./lib/commands"
+    "commands": {
+      "strategy": "single",
+      "target": "./lib/commands/index"
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- trigger semantic release only after the CI workflow completes successfully on  or 
- stop rerunning lint and tests inside the semantic release workflow
- move Coveralls upload to the CI test job where coverage is produced

## Why
- the release workflow was failing on  because it re-ran tests in a separate workflow without sharing CI setup assumptions
- making release depend on CI removes duplicate validation logic and keeps release gated on the tested commit
