### PR TITLE
feat: add modifiers CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ export type TypeAnimalWithAllLocalesResponse<Locales extends LocaleCode = Locale
 
 ### `-m, --modifiers`
 
-Adds default modifiers to resolved types. Multiple modifiers are allows and will be unionized. Valid options are `WITH_ALL_LOCALES`, `WITHOUT_LINK_RESOLUTION`, and `WITHOUT_UNRESOLVABLE_LINKS`.
+Adds default modifiers to resolved types. Multiple modifiers are allows and will be unionized. Valid options are `WITH_ALL_LOCALES`, `WITHOUT_LINK_RESOLUTION`, `WITHOUT_UNRESOLVABLE_LINKS`, `WITH_LOCALE_BASED_PUBLISHING`, `undefined`.
 
 ```
 --modifiers WITH_ALL_LOCALES --modifiers WITHOUT_LINK_RESOLUTION

--- a/README.md
+++ b/README.md
@@ -170,7 +170,20 @@ export type TypeAnimalWithAllLocalesResponse<Locales extends LocaleCode = Locale
 >;
 ```
 
-These aliases are convenience aliases for the top-level entry type only. Linked entries still stay typed as `Entry<LinkedSkeleton, Modifiers, Locales>`, which is expected and matches `contentful.js`.
+### `-m, --modifiers`
+
+Adds default modifiers to resolved types. Multiple modifiers are allows and will be unionized. Valid options are `WITH_ALL_LOCALES`, `WITHOUT_LINK_RESOLUTION`, and `WITHOUT_UNRESOLVABLE_LINKS`.
+
+```
+--modifiers WITH_ALL_LOCALES --modifiers WITHOUT_LINK_RESOLUTION
+```
+
+```ts
+export type TypeAnimal<
+  Modifiers extends ChainModifiers = 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
+  Locales extends LocaleCode = LocaleCode,
+> = Entry<TypeAnimalSkeleton, Modifiers, Locales>;
+```
 
 ### Link Resolution Tips
 

--- a/src/cli/create-renderers.ts
+++ b/src/cli/create-renderers.ts
@@ -12,6 +12,7 @@ export type RendererFlags = {
   jsdoc?: boolean;
   typeguard?: boolean;
   response?: boolean;
+  modifiers?: string[];
 };
 
 export const createRenderers = (
@@ -26,7 +27,7 @@ export const createRenderers = (
     onError('"--localized" was removed. Localization support is built into the default output.');
   }
 
-  const renderers: Renderer[] = [new ContentTypeRenderer()];
+  const renderers: Renderer[] = [new ContentTypeRenderer({ defaultModifiers: flags.modifiers })];
 
   if (flags.jsdoc) {
     renderers.push(new JsDocRenderer());

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -32,7 +32,13 @@ class ContentfulMdg extends Command {
       char: 'm',
       description: 'default Modifiers type parameter value',
       multiple: true,
-      options: ['WITH_ALL_LOCALES', 'WITHOUT_LINK_RESOLUTION', 'WITHOUT_UNRESOLVABLE_LINKS'],
+      options: [
+        'WITH_ALL_LOCALES',
+        'WITHOUT_LINK_RESOLUTION',
+        'WITHOUT_UNRESOLVABLE_LINKS',
+        'WITH_LOCALE_BASED_PUBLISHING',
+        'undefined',
+      ],
     }),
 
     // remote access

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -28,6 +28,12 @@ class ContentfulMdg extends Command {
     jsdoc: Flags.boolean({ char: 'd', description: 'add JSDoc comments' }),
     typeguard: Flags.boolean({ char: 'g', description: 'add modern type guards' }),
     response: Flags.boolean({ char: 'r', description: 'add response types' }),
+    modifiers: Flags.string({
+      char: 'm',
+      description: 'default Modifiers type parameter value',
+      multiple: true,
+      options: ['WITH_ALL_LOCALES', 'WITHOUT_LINK_RESOLUTION', 'WITHOUT_UNRESOLVABLE_LINKS'],
+    }),
 
     // remote access
     spaceId: Flags.string({ char: 's', description: 'space id' }),

--- a/src/renderer/generic/render-type-literal.ts
+++ b/src/renderer/generic/render-type-literal.ts
@@ -1,3 +1,9 @@
 export const renderTypeLiteral = (value: string): string => {
+  if (value === 'undefined') {
+    return 'undefined';
+  }
+  if (value === 'null') {
+    return 'null';
+  }
   return JSON.stringify(value);
 };

--- a/src/renderer/type/content-type-renderer.ts
+++ b/src/renderer/type/content-type-renderer.ts
@@ -11,7 +11,21 @@ import { CFContentType } from '../../types';
 import { BaseContentTypeRenderer } from './base-content-type-renderer';
 import { createContext, RenderContext } from './create-context';
 
+export type ContentTypeRendererOptions = {
+  defaultModifiers: string[];
+};
+
+const defaultContentTypeRendererOptions: ContentTypeRendererOptions = {
+  defaultModifiers: [],
+};
+
 export class ContentTypeRenderer extends BaseContentTypeRenderer {
+  private readonly options: ContentTypeRendererOptions;
+  constructor(options?: Partial<ContentTypeRendererOptions>) {
+    super();
+    this.options = { ...defaultContentTypeRendererOptions, ...options };
+  }
+
   public render(contentType: CFContentType, file: SourceFile): void {
     const context = this.createContext();
 
@@ -97,10 +111,14 @@ export class ContentTypeRenderer extends BaseContentTypeRenderer {
     contentType: CFContentType,
     context: RenderContext,
   ): OptionalKind<TypeAliasDeclarationStructure> {
+    const modifiersParam = this.options.defaultModifiers.length
+      ? `Modifiers extends ChainModifiers = ${this.options.defaultModifiers.map((m) => `"${m}"`).join(' | ')}`
+      : 'Modifiers extends ChainModifiers';
+
     return {
       name: renderTypeGeneric(
         context.moduleName(contentType.sys.id),
-        'Modifiers extends ChainModifiers',
+        modifiersParam,
         'Locales extends LocaleCode = LocaleCode',
       ),
       isExported: true,

--- a/src/renderer/type/content-type-renderer.ts
+++ b/src/renderer/type/content-type-renderer.ts
@@ -6,7 +6,7 @@ import {
   TypeAliasDeclarationStructure,
 } from 'ts-morph';
 import { propertyImports } from '../../property-imports';
-import { renderTypeGeneric } from '../generic';
+import { renderTypeGeneric, renderTypeLiteral, renderTypeUnion } from '../generic';
 import { CFContentType } from '../../types';
 import { BaseContentTypeRenderer } from './base-content-type-renderer';
 import { createContext, RenderContext } from './create-context';
@@ -23,7 +23,10 @@ export class ContentTypeRenderer extends BaseContentTypeRenderer {
   private readonly options: ContentTypeRendererOptions;
   constructor(options?: Partial<ContentTypeRendererOptions>) {
     super();
-    this.options = { ...defaultContentTypeRendererOptions, ...options };
+    this.options = {
+      defaultModifiers:
+        options?.defaultModifiers ?? defaultContentTypeRendererOptions.defaultModifiers,
+    };
   }
 
   public render(contentType: CFContentType, file: SourceFile): void {
@@ -112,7 +115,7 @@ export class ContentTypeRenderer extends BaseContentTypeRenderer {
     context: RenderContext,
   ): OptionalKind<TypeAliasDeclarationStructure> {
     const modifiersParam = this.options.defaultModifiers.length
-      ? `Modifiers extends ChainModifiers = ${this.options.defaultModifiers.map((m) => `"${m}"`).join(' | ')}`
+      ? `Modifiers extends ChainModifiers = ${renderTypeUnion(this.options.defaultModifiers.map(renderTypeLiteral))}`
       : 'Modifiers extends ChainModifiers';
 
     return {

--- a/test/rendered/generic/render-type-literal.test.ts
+++ b/test/rendered/generic/render-type-literal.test.ts
@@ -7,4 +7,10 @@ describe('A renderTypeLiteral function', () => {
   it('renders a string with an escapable character', () => {
     expect(renderTypeLiteral('foo\nbar')).toEqual('"foo\\nbar"');
   });
+  it('renders the string "undefined" as the literal undefined', () => {
+    expect(renderTypeLiteral('undefined')).toEqual('undefined');
+  });
+  it('renders the string "null" as the literal null', () => {
+    expect(renderTypeLiteral('null')).toEqual('null');
+  });
 });

--- a/test/renderer/type/content-type-renderer.test.ts
+++ b/test/renderer/type/content-type-renderer.test.ts
@@ -98,6 +98,30 @@ describe('ContentTypeRenderer', () => {
     );
   });
 
+  it('renders with a single default undefined modifier', () => {
+    const renderer = new ContentTypeRenderer({ defaultModifiers: ['undefined'] });
+
+    const contentType: CFContentType = {
+      name: 'unused-name',
+      sys: { id: 'test', type: 'Symbol' },
+      fields: [],
+    };
+
+    renderer.render(contentType, testFile);
+
+    expect(('\n' + testFile.getFullText()).trim()).toEqual(
+      stripIndent(`
+        import type { ChainModifiers, Entry, EntrySkeletonType, LocaleCode } from "contentful";
+
+        export interface TypeTestFields {
+        }
+
+        export type TypeTestSkeleton = EntrySkeletonType<TypeTestFields, "test">;
+        export type TypeTest<Modifiers extends ChainModifiers = undefined, Locales extends LocaleCode = LocaleCode> = Entry<TypeTestSkeleton, Modifiers, Locales>;
+      `).trim(),
+    );
+  });
+
   it('renders with multiple default modifiers as a union', () => {
     const renderer = new ContentTypeRenderer({
       defaultModifiers: ['WITH_ALL_LOCALES', 'WITHOUT_LINK_RESOLUTION'],

--- a/test/renderer/type/content-type-renderer.test.ts
+++ b/test/renderer/type/content-type-renderer.test.ts
@@ -73,6 +73,56 @@ describe('ContentTypeRenderer', () => {
       `).trim(),
     );
   });
+
+  it('renders with a single default modifier', () => {
+    const renderer = new ContentTypeRenderer({ defaultModifiers: ['WITHOUT_LINK_RESOLUTION'] });
+
+    const contentType: CFContentType = {
+      name: 'unused-name',
+      sys: { id: 'test', type: 'Symbol' },
+      fields: [],
+    };
+
+    renderer.render(contentType, testFile);
+
+    expect(('\n' + testFile.getFullText()).trim()).toEqual(
+      stripIndent(`
+        import type { ChainModifiers, Entry, EntrySkeletonType, LocaleCode } from "contentful";
+
+        export interface TypeTestFields {
+        }
+
+        export type TypeTestSkeleton = EntrySkeletonType<TypeTestFields, "test">;
+        export type TypeTest<Modifiers extends ChainModifiers = "WITHOUT_LINK_RESOLUTION", Locales extends LocaleCode = LocaleCode> = Entry<TypeTestSkeleton, Modifiers, Locales>;
+      `).trim(),
+    );
+  });
+
+  it('renders with multiple default modifiers as a union', () => {
+    const renderer = new ContentTypeRenderer({
+      defaultModifiers: ['WITH_ALL_LOCALES', 'WITHOUT_LINK_RESOLUTION'],
+    });
+
+    const contentType: CFContentType = {
+      name: 'unused-name',
+      sys: { id: 'test', type: 'Symbol' },
+      fields: [],
+    };
+
+    renderer.render(contentType, testFile);
+
+    expect(('\n' + testFile.getFullText()).trim()).toEqual(
+      stripIndent(`
+        import type { ChainModifiers, Entry, EntrySkeletonType, LocaleCode } from "contentful";
+
+        export interface TypeTestFields {
+        }
+
+        export type TypeTestSkeleton = EntrySkeletonType<TypeTestFields, "test">;
+        export type TypeTest<Modifiers extends ChainModifiers = "WITH_ALL_LOCALES" | "WITHOUT_LINK_RESOLUTION", Locales extends LocaleCode = LocaleCode> = Entry<TypeTestSkeleton, Modifiers, Locales>;
+      `).trim(),
+    );
+  });
 });
 
 const symbolTypeRenderer = () => {

--- a/test/renderer/type/content-type-renderer.test.ts
+++ b/test/renderer/type/content-type-renderer.test.ts
@@ -119,7 +119,7 @@ describe('ContentTypeRenderer', () => {
         }
 
         export type TypeTestSkeleton = EntrySkeletonType<TypeTestFields, "test">;
-        export type TypeTest<Modifiers extends ChainModifiers = "WITH_ALL_LOCALES" | "WITHOUT_LINK_RESOLUTION", Locales extends LocaleCode = LocaleCode> = Entry<TypeTestSkeleton, Modifiers, Locales>;
+        export type TypeTest<Modifiers extends ChainModifiers = "WITHOUT_LINK_RESOLUTION" | "WITH_ALL_LOCALES", Locales extends LocaleCode = LocaleCode> = Entry<TypeTestSkeleton, Modifiers, Locales>;
       `).trim(),
     );
   });


### PR DESCRIPTION
Is there any preference between the CLI argument being `--modifiers` vs `--default-modifiers`? I just felt weird about having `--default-modifiers` shorthanded to `-m`.