### PR TITLE
feat: add overloads to type guard functions for generic inference

### DIFF
--- a/src/internal/write-output.ts
+++ b/src/internal/write-output.ts
@@ -59,6 +59,8 @@ export class DefinitionsOutputWriter {
           case StructureKind.Function:
             mergeFile.addFunction(childStructure);
             break;
+          case StructureKind.FunctionOverload:
+            break;
           default:
             throw new Error(`Unhandled node type '${StructureKind[childStructure.kind]}'.`);
         }

--- a/src/renderer/type/type-guard-renderer.ts
+++ b/src/renderer/type/type-guard-renderer.ts
@@ -25,6 +25,8 @@ export class TypeGuardRenderer extends BaseContentTypeRenderer {
       isTypeOnly: true,
     });
 
+    const returnType = `entry is ${renderTypeGeneric(entryInterfaceName, 'Modifiers', 'Locales')}`;
+
     file.addFunction({
       isExported: true,
       name: renderTypeGeneric(
@@ -32,7 +34,7 @@ export class TypeGuardRenderer extends BaseContentTypeRenderer {
         'Modifiers extends ChainModifiers',
         'Locales extends LocaleCode',
       ),
-      returnType: `entry is ${renderTypeGeneric(entryInterfaceName, 'Modifiers', 'Locales')}`,
+      returnType,
       parameters: [
         {
           name: 'entry',
@@ -42,6 +44,29 @@ export class TypeGuardRenderer extends BaseContentTypeRenderer {
       statements: [
         `const candidate = entry as { sys?: { contentType?: { sys?: { id?: string } } } };`,
         `return candidate.sys?.contentType?.sys?.id === '${contentType.sys.id}'`,
+      ],
+      overloads: [
+        {
+          isExported: true,
+          returnType,
+          parameters: [
+            {
+              name: 'entry',
+              type: renderTypeGeneric('Entry', 'EntrySkeletonType', 'Modifiers', 'Locales'),
+              hasQuestionToken: true,
+            },
+          ],
+        },
+        {
+          isExported: true,
+          returnType,
+          parameters: [
+            {
+              name: 'entry',
+              type: 'unknown',
+            },
+          ],
+        },
       ],
     });
 

--- a/test/cf-definitions-builder.test.ts
+++ b/test/cf-definitions-builder.test.ts
@@ -124,8 +124,12 @@ describe('A Contentful definitions builder', () => {
     builder = new CFDefinitionsBuilder([new ContentTypeRenderer(), new TypeGuardRenderer()]);
     builder.appendType(modelType);
 
-    expect(builder.toString()).toContain(
-      'export function isTypeSysId<Modifiers extends ChainModifiers, Locales extends LocaleCode>',
+    const output = builder.toString();
+    expect(output).toContain(
+      'export function isTypeSysId<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry?: Entry<EntrySkeletonType, Modifiers, Locales>)',
+    );
+    expect(output).toContain(
+      'export function isTypeSysId<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry: unknown)',
     );
   });
 

--- a/test/renderer/type/type-guard-renderer.test.ts
+++ b/test/renderer/type/type-guard-renderer.test.ts
@@ -57,6 +57,8 @@ describe('TypeGuardRenderer', () => {
         export type TypeAnimalSkeleton = EntrySkeletonType<TypeAnimalFields, "animal">;
         export type TypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode = LocaleCode> = Entry<TypeAnimalSkeleton, Modifiers, Locales>;
 
+        export function isTypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry?: Entry<EntrySkeletonType, Modifiers, Locales>): entry is TypeAnimal<Modifiers, Locales>;
+        export function isTypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry: unknown): entry is TypeAnimal<Modifiers, Locales>;
         export function isTypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry: unknown): entry is TypeAnimal<Modifiers, Locales> {
             const candidate = entry as { sys?: { contentType?: { sys?: { id?: string } } } };
             return candidate.sys?.contentType?.sys?.id === 'animal'


### PR DESCRIPTION
## What this does

Adds two overload signatures to each generated type guard function so that TypeScript can infer `Modifiers` and `Locales` from the argument, removing the need to pass them explicitly.

Before this change, every call required explicit type parameters:

```ts
if (isTypeAnimal<WithAllLocales, 'en-US'>(entry)) { ... }
```

After this change, when the argument is already typed as an `Entry`, the type parameters are inferred automatically:

```ts
if (isTypeAnimal(entry)) { ... }
```

The two overloads added to each guard are:

1. `(entry?: Entry<EntrySkeletonType, Modifiers, Locales>)` — matches typed `Entry` values and enables inference
2. `(entry: unknown)` — matches any other value

## Not a breaking change

The original function signature (`entry: unknown`) is preserved as the implementation signature and is also exposed as an explicit overload, so all existing call patterns continue to work unchanged. Callers who pass an `unknown`-typed value and supply explicit type parameters explicitly will see no difference in behavior.

The only new behavior is that callers who pass a value already typed as `Entry<..., Modifiers, Locales>` no longer need to spell out `Modifiers` and `Locales` — TypeScript infers them.

## Additional fix

`StructureKind.FunctionOverload` is now handled in `DefinitionsOutputWriter` to prevent an unhandled-node error when building single-file output from content types that use overloads. Overload structures are emitted as siblings of their parent function by ts-morph's `forEachStructureChild`, so they need to be explicitly skipped (the implementation function node already carries the full function including overloads when passed to `addFunction`).