### PR TITLE
ci(github-actions): add explicit permissions to CI workflow [ACT-2435] [ACT-2436] [ACT-2441]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
@@ -59,6 +62,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Adds explicit \`permissions\` blocks to \`.github/workflows/test.yml\` to restrict the \`GITHUB_TOKEN\` to the minimum required scopes across all three CI jobs. A workflow-level \`contents: read\` default covers the \`build\` and \`lint\` jobs; the \`test\` job also gets \`checks: write\` so the Coveralls action can post results.

## Tickets

- ACT-2435 — \`lint\` job missing permissions (lines 32–59)
- ACT-2436 — \`build\` job missing permissions (lines 7–31)
- ACT-2441 — \`test\` job missing permissions (lines 60–90)

## Why

Without explicit permissions the workflow inherits the repository default, which may be read-write. Least-privilege permissions prevent accidental or malicious use of a broad token and follow Contentful security requirements for public repositories.

## Risk and Rollout

Low risk — CI configuration change only. The \`GITHUB_TOKEN\` now has narrower scope. If any job requires additional permissions in the future, they can be added at the job level.

> Note: This PR was created with the [contentful-github-create-pull-request](https://github.com/contentful/agents-kit/tree/main/libs/contentful-github-create-pull-request) skill, powered by [Agents Kit].
> Learn more: [Agents Kit Documentation](https://contentful.roadie.so/docs/default/component/agents-kit).